### PR TITLE
Macro fixes

### DIFF
--- a/dbus-pure-macros/src/as_variant.rs
+++ b/dbus-pure-macros/src/as_variant.rs
@@ -16,20 +16,20 @@ pub(super) fn run(input: proc_macro::TokenStream) -> Result<proc_macro2::TokenSt
 
 			let fields_signature =
 				fields.iter()
-				.map(|syn::Field { ty, .. }| quote::quote! { <#ty as dbus_pure_proto::AsVariant>::signature() });
+				.map(|syn::Field { ty, .. }| quote::quote! { <#ty as dbus_pure::proto::AsVariant>::signature() });
 
 			let fields_as_variant =
 				fields.iter()
-				.map(|syn::Field { ident, .. }| quote::quote! { <_ as dbus_pure_proto::AsVariant>::as_variant(&self.#ident) });
+				.map(|syn::Field { ident, .. }| quote::quote! { <_ as dbus_pure::proto::AsVariant>::as_variant(&self.#ident) });
 
 			(
 				quote::quote! {
-					dbus_pure_proto::Signature::Struct {
+					dbus_pure::proto::Signature::Struct {
 						fields: vec![#(#fields_signature ,)*],
 					}
 				},
 				quote::quote! {
-					dbus_pure_proto::Variant::Struct {
+					dbus_pure::proto::Variant::Struct {
 						fields: vec![#(#fields_as_variant ,)*].into(),
 					}
 				},
@@ -43,10 +43,10 @@ pub(super) fn run(input: proc_macro::TokenStream) -> Result<proc_macro2::TokenSt
 
 			(
 				quote::quote! {
-					<#ty as dbus_pure_proto::AsVariant>::signature()
+					<#ty as dbus_pure::proto::AsVariant>::signature()
 				},
 				quote::quote! {
-					<dbus_pure_proto::AsVariant>::as_variant(&self.0)
+					<dbus_pure::proto::AsVariant>::as_variant(&self.0)
 				},
 			)
 		},
@@ -62,12 +62,12 @@ pub(super) fn run(input: proc_macro::TokenStream) -> Result<proc_macro2::TokenSt
 	};
 
 	let result = quote::quote! {
-		impl #impl_generics dbus_pure_proto::AsVariant for #ident #ty_generics #where_clause {
-			fn signature() -> dbus_pure_proto::Signature {
+		impl #impl_generics dbus_pure::proto::AsVariant for #ident #ty_generics #where_clause {
+			fn signature() -> dbus_pure::proto::Signature {
 				#signature_body
 			}
 
-			fn as_variant<'__a>(&'__a self) -> dbus_pure_proto::Variant<'__a> {
+			fn as_variant<'__a>(&'__a self) -> dbus_pure::proto::Variant<'__a> {
 				#as_variant_body
 			}
 		}

--- a/dbus-pure-macros/src/interface.rs
+++ b/dbus-pure-macros/src/interface.rs
@@ -123,7 +123,7 @@ pub(super) fn run(attr: proc_macro::TokenStream, item: proc_macro::TokenStream) 
 				&self,
 				client: &mut dbus_pure::Client,
 				#args
-			) -> Result<#return_ty, dbus_pure::MethodCallError> {
+			) -> std::result::Result<#return_ty, dbus_pure::MethodCallError> {
 				let body =
 					client.method_call(
 						self.name(),


### PR DESCRIPTION
Fix two minor macro hygiene issues:

* Use the absolute path for `Result` in the `interface` macro so it works when the surrounding code has its own `Result` type.
* Make `AsVariant` use `dbus_pure::proto` instead of `dbus_pure_proto`, so crates using this macro do not need to add an explicit dependency on the latter.